### PR TITLE
Expose Android proximity sensor methods

### DIFF
--- a/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
@@ -422,8 +422,8 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
         sendEvent("Proximity", data);
     }
 
-
-    private void startProximitySensor() {
+    @ReactMethod
+    public void startProximitySensor() {
         if (!proximityManager.isProximitySupported()) {
             Log.d(TAG, "Proximity Sensor is not supported.");
             return;
@@ -441,7 +441,8 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
         isProximityRegistered = true;
     }
 
-    private void stopProximitySensor() {
+    @ReactMethod
+    public void stopProximitySensor() {
         if (!proximityManager.isProximitySupported()) {
             Log.d(TAG, "Proximity Sensor is not supported.");
             return;

--- a/index.js
+++ b/index.js
@@ -114,6 +114,14 @@ class InCallManager {
         _InCallManager.stopRingback();
     }
 
+    stopProximitySensor() {
+        _InCallManager.stopProximitySensor();
+    }
+
+    startProximitySensor() {
+        _InCallManager.startProximitySensor();
+    }
+
     async checkRecordPermission() {
         // --- on android which api < 23, it will always be "granted"
         let result = await _InCallManager.checkRecordPermission();


### PR DESCRIPTION
Hi,

I encounter an issue with Android devices proximity sensor.
If the user picked up the phone to his ear too quick the JS thread was paused.
Disabling the proximity sensor when the user picked up fix the issue.

This PR just expose the methods that allow proximity sensor control on Android.

Thanks.