### PR TITLE
Fix for InCallManager.start() Ringback make setInterval() to faster

### DIFF
--- a/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
@@ -574,6 +574,10 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
             });
             // TODO: even if not acquired focus, we can still play sounds. but need figure out which is better.
             //getCurrentActivity().setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
+            if (!ringbackUriType.isEmpty()) {
+                startRingback(ringbackUriType);
+                defaultAudioMode = AudioManager.MODE_NORMAL;
+            }            
             audioManager.setMode(defaultAudioMode);
             setSpeakerphoneOn(defaultSpeakerOn);
             setMicrophoneMute(false);
@@ -585,9 +589,6 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
             audioDevices.clear();
             updateAudioRoute();
 
-            if (!ringbackUriType.isEmpty()) {
-                startRingback(ringbackUriType);
-            }
         }
     }
 


### PR DESCRIPTION
Like "InCallManager.start({ media: 'video', ringback: '_DTMF_' });" Ringbacks makes setInterval() to faster
if you run after ringback setInterval(()=>{console.log("after 1 second")},1000) its log in it less than 1 second
When used MODE_NORMAL for ringback its fixed up.

defaultAudioMode = AudioManager.MODE_NORMAL; //For Ringback 
defaultAudioMode = AudioManager.MODE_IN_COMMUNICATION; // For Incall