### PR TITLE
AppRTCBluetoothManager | Redundantly handle null case when unregistering

### DIFF
--- a/android/src/main/java/com/zxcpoiu/incallmanager/AppRTC/AppRTCBluetoothManager.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/AppRTC/AppRTCBluetoothManager.java
@@ -468,7 +468,15 @@ public class AppRTCBluetoothManager {
     }
   }
   protected void unregisterReceiver(BroadcastReceiver receiver) {
-    apprtcContext.unregisterReceiver(receiver);
+    if (receiver != null) {
+        try {
+            apprtcContext.unregisterReceiver(receiver);
+        } catch (final Exception exception) {
+            // The receiver was not registered.
+            // There is nothing to do in that case.
+            // Everything is fine.
+        }
+    }
   }
   protected boolean getBluetoothProfileProxy(
       Context context, BluetoothProfile.ServiceListener listener, int profile) {


### PR DESCRIPTION
i don't have nice experience with Android in general but I did have this code on a production project and reduced a lot of crashlogs-- I kinda don't understand why `receiver` at this point would be null