### PR TITLE
fix(android): Resets bluetooth state after disconnecting from the only available headset

### DIFF
--- a/android/src/main/java/com/zxcpoiu/incallmanager/AppRTC/AppRTCBluetoothManager.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/AppRTC/AppRTCBluetoothManager.java
@@ -145,6 +145,7 @@ public class AppRTCBluetoothManager {
       boolean needChange = false;
       if (bluetoothAudioDevice != null && newBtDevice == null) {
         needChange = true;
+        bluetoothState = State.HEADSET_UNAVAILABLE;
       } else if (bluetoothAudioDevice == null && newBtDevice != null) {
         needChange = true;
       } else if (bluetoothAudioDevice != null && bluetoothAudioDevice.getId() != newBtDevice.getId()) {


### PR DESCRIPTION
Detailed Explanation can be found in the issue here:
https://github.com/react-native-webrtc/react-native-incall-manager/issues/243

